### PR TITLE
Organize profile preview functionality

### DIFF
--- a/Assets/Emojis.py
+++ b/Assets/Emojis.py
@@ -19,6 +19,7 @@ class BotEmojis:
     Cross = PartialEmoji.from_str("❌")
     Diamond = PartialEmoji.from_str("💠")
     Drum = PartialEmoji.from_str("🥁")
+    EmojiMonocle = PartialEmoji.from_str("🧐")
     Envelope = PartialEmoji.from_str("💌")
     Eyes = PartialEmoji.from_str("👀")
     FlyingEnvelope = PartialEmoji.from_str("📨")

--- a/Classes/Profiles/Profile.py
+++ b/Classes/Profiles/Profile.py
@@ -215,31 +215,13 @@ class Profile(ManagedObject):
 ################################################################################
     async def preview_profile(self, interaction: Interaction) -> None:
 
-        main_profile, _ = self.compile()
+        main_profile, about_me = self.compile()
+        embeds = [main_profile]
+        if about_me is not None:
+            embeds.append(about_me)
         view = CloseMessageView(interaction.user)
 
-        await interaction.respond(embed=main_profile, view=view)
-        await view.wait()
-
-################################################################################
-    async def preview_aboutme(self, interaction: Interaction) -> None:
-
-        _, aboutme = self.compile()
-        if aboutme is None:
-            error = U.make_error(
-                title="About Me Not Set",
-                message="You can't view an empty About Me section.",
-                solution=(
-                    "Fill it out in the `Profile Personality` section before "
-                    "trying again."
-                )
-            )
-            await interaction.respond(embed=error, ephemeral=True)
-            return
-
-        view = CloseMessageView(interaction.user)
-
-        await interaction.respond(embed=aboutme, view=view)
+        await interaction.respond(embeds=embeds, view=view)
         await view.wait()
 
 ################################################################################

--- a/UI/Profiles/Views/ProfileMainMenuView.py
+++ b/UI/Profiles/Views/ProfileMainMenuView.py
@@ -25,10 +25,9 @@ class ProfileMainMenuView(FroggeView):
             AtAGlanceButton(),
             PersonalityButton(),
             ImagesButton(),
-            PreviewProfileButton(),
-            PreviewAboutMeButton(),
             PostProfileButton(),
             ProfileProgressButton(),
+            PreviewProfileButton(),
             CloseMessageButton()
         ]
         for btn in button_list:
@@ -102,29 +101,15 @@ class PreviewProfileButton(FroggeButton):
     def __init__(self):
         
         super().__init__(
-            style=ButtonStyle.primary,
+            style=ButtonStyle.secondary,
             label="Preview Profile",
             disabled=False,
-            row=1
+            row=1,
+            emoji=BotEmojis.EmojiMonocle
         )
         
     async def callback(self, interaction: Interaction):
         await self.view.ctx.preview_profile(interaction)
-        
-################################################################################
-class PreviewAboutMeButton(FroggeButton):
-    
-    def __init__(self):
-        
-        super().__init__(
-            style=ButtonStyle.primary,
-            label="Preview About Me",
-            disabled=False,
-            row=1
-        )
-        
-    async def callback(self, interaction: Interaction):
-        await self.view.ctx.preview_aboutme(interaction)
         
 ################################################################################
 class PostProfileButton(FroggeButton):
@@ -135,7 +120,7 @@ class PostProfileButton(FroggeButton):
             style=ButtonStyle.secondary,
             label="Post/Update Profile",
             disabled=False,
-            row=2,
+            row=1,
             emoji=BotEmojis.FlyingEnvelope
         )
         
@@ -151,7 +136,7 @@ class ProfileProgressButton(FroggeButton):
             style=ButtonStyle.secondary,
             label="Profile Progress",
             disabled=False,
-            row=2,
+            row=1,
             emoji=BotEmojis.Goose
         )
         


### PR DESCRIPTION
Refactor profile preview to combine main and 'About Me' sections into a single interaction if 'About Me' is set. Removed redundant 'Preview About Me' button and adjusted UI elements accordingly with updated emojis.