### PR TITLE
channel-select-menu-conversion

### DIFF
--- a/Classes/Activities/ActivityManager.py
+++ b/Classes/Activities/ActivityManager.py
@@ -156,11 +156,11 @@ class ActivityManager(ObjectManager, ABC):
                 f"`{self.activity_name.lower()}s`."
             )
         )
-        channel = await U.listen_for(
+        channel = await U.select_channel(
             interaction=interaction,
-            prompt=prompt,
-            mentionable_type=U.MentionableType.Channel,
-            channel_restrictions=[ChannelType.text, ChannelType.forum]
+            guild=self.guild,
+            channel_type=f"{self.activity_name.title()} Channel",
+            channel_prompt=prompt
         )
         if channel is None:
             return

--- a/Classes/Core/GuildConfig.py
+++ b/Classes/Core/GuildConfig.py
@@ -161,9 +161,7 @@ class GuildConfiguration(FroggeObject):
             )
         )
 
-        channel = await U.listen_for(
-            interaction, prompt, U.MentionableType.Channel, [ChannelType.text]
-        )
+        channel = await U.select_channel(interaction, self.guild, "Log Stream Channel", prompt)
         if channel is None:
             return
 

--- a/Classes/Embeds/FroggeEmbed.py
+++ b/Classes/Embeds/FroggeEmbed.py
@@ -455,7 +455,7 @@ class FroggeEmbed(ManagedObject):
                 "Please enter the channel you want to post this embed to."
             )
         )
-        channel = await U.listen_for(interaction, prompt, U.MentionableType.Channel, [ChannelType.text])
+        channel = await U.select_channel(interaction, self.guild, "Embed Channel", prompt)
         if channel is None:
             return
 

--- a/Classes/Events/EventManager.py
+++ b/Classes/Events/EventManager.py
@@ -308,16 +308,14 @@ class EventManager(ObjectManager):
         prompt = U.make_embed(
             title="__Set Scheduling Channel__",
             description=(
-                "Please mention the channel where event scheduling messages will be sent.\n\n"
-
-                "This channel may be a standard text channel or a forum channel."
+                "Please select the channel where event scheduling messages will be sent."
             )
         )
-        channel = await U.listen_for(
+        channel = await U.select_channel(
             interaction=interaction,
-            prompt=prompt,
-            mentionable_type=U.MentionableType.Channel,
-            channel_restrictions=[ChannelType.text, ChannelType.forum]
+            guild=self.guild,
+            channel_type="Scheduling Channel",
+            channel_prompt=prompt
         )
         if channel is None:
             return

--- a/Classes/Forms/Form.py
+++ b/Classes/Forms/Form.py
@@ -399,9 +399,9 @@ class Form(ManagedObject):
 
         prompt = U.make_embed(
             title="__Set Form Log Channel__",
-            description="Mention the channel where form responses should be logged."
+            description="Select the channel where form responses should be logged."
         )
-        channel = await U.listen_for(interaction, prompt, U.MentionableType.Channel)
+        channel = await U.select_channel(interaction, self.guild, "Form Log Channel", prompt)
         if channel is None:
             return
 

--- a/Classes/Forms/FormPostOptions.py
+++ b/Classes/Forms/FormPostOptions.py
@@ -295,12 +295,10 @@ class FormPostOptions:
         prompt = U.make_embed(
             title="Set Form Post Channel",
             description=(
-                "Please mention the channel you would like to use for this form post."
+                "Please select the channel you would like to use for this form post."
             )
         )
-        channel = await U.listen_for(
-            interaction, prompt, U.MentionableType.Channel, [ChannelType.text]
-        )
+        channel = await U.select_channel(interaction, self.guild, "Form Post Channel", prompt)
         if channel is not None:
             self.post_channel = channel
 

--- a/Classes/Profiles/ProfileChannelGroup.py
+++ b/Classes/Profiles/ProfileChannelGroup.py
@@ -173,15 +173,15 @@ class ProfileChannelGroup(ManagedObject):
         prompt = U.make_embed(
             title="__Add Posting Channel__",
             description=(
-                "Please mention the channel you would like to add to this "
+                "Please select the channel you would like to add to this "
                 "posting channel group."
             )
         )
-        channel = await U.listen_for(
+        channel = await U.select_channel(
             interaction=interaction, 
-            prompt=prompt, 
-            mentionable_type=U.MentionableType.Channel,
-            channel_restrictions=[ChannelType.text, ChannelType.forum]
+            guild=self.guild,
+            channel_type="Profile Posting Channel",
+            channel_prompt=prompt
         )
         if channel is None:
             return

--- a/Classes/Raffles/Raffle.py
+++ b/Classes/Raffles/Raffle.py
@@ -307,7 +307,7 @@ class Raffle(BaseActivity):
                 "*(This message will be updated automatically as tickets are added.)*"
             )
         )
-        channel = await U.listen_for(interaction, prompt, U.MentionableType.Channel, [ChannelType.text])
+        channel = await U.select_channel(interaction, self.guild, "Raffle Tracker Channel", prompt)
         if channel is None:
             return
 

--- a/Classes/ReactionRoles/ReactionRoleManager.py
+++ b/Classes/ReactionRoles/ReactionRoleManager.py
@@ -259,15 +259,16 @@ class ReactionRoleManager(ObjectManager):
         prompt = U.make_embed(
             title="__Set Reaction Roles Channel__",
             description=(
-                "Please mention the channel where you would like to set up the Reaction Roles."
+                "Please select the channel where you would like to set up the "
+                "Reaction Roles."
             )
         )
 
-        channel = await U.listen_for(
+        channel = await U.select_channel(
             interaction=interaction,
-            prompt=prompt,
-            mentionable_type=U.MentionableType.Channel,
-            channel_restrictions=[ChannelType.text]
+            guild=self.guild,
+            channel_type="Reaction Roles Channel",
+            channel_prompt=prompt
         )
         if channel is None:
             return

--- a/Classes/Rooms/RoomsManager.py
+++ b/Classes/Rooms/RoomsManager.py
@@ -184,10 +184,10 @@ class RoomsManager(ObjectManager):
         prompt = U.make_embed(
             title="__Set Rooms Channel__",
             description=(
-                "Please mention the channel you would like to use for the Rooms module."
+                "Please select the channel you would like to use for the Rooms module."
             )
         )
-        channel = await U.listen_for(interaction, prompt, U.MentionableType.Channel)
+        channel = await U.select_channel(interaction, self.guild, "Rooms Channel", prompt)
         if channel is None:
             return
 

--- a/Classes/VIPs/VIPManager.py
+++ b/Classes/VIPs/VIPManager.py
@@ -379,7 +379,7 @@ class VIPManager:
                 "the VIP List to be posted."
             )
         )
-        channel = await U.listen_for(interaction, prompt, U.MentionableType.Channel)
+        channel = await U.select_channel(interaction, self.guild, "VIP List Channel", prompt)
         if channel is not None:
             try:
                 post_message = await channel.send(embeds=await self.compile())
@@ -401,7 +401,7 @@ class VIPManager:
                 "the VIP Perks List message to be posted."
             )
         )
-        channel = await U.listen_for(interaction, prompt, U.MentionableType.Channel)
+        channel = await U.select_channel(interaction, self.guild, "VIP Perks Channel", prompt)
         if channel is not None:
             try:
                 post_message = await channel.send(embed=self.perks_compile())

--- a/Utilities/Utilities.py
+++ b/Utilities/Utilities.py
@@ -18,7 +18,7 @@ from discord import (
     ChannelType,
     User,
     Role,
-    Emoji, SelectOption
+    Emoji, SelectOption, TextChannel, ForumChannel
 )
 from discord.abc import GuildChannel
 
@@ -585,12 +585,12 @@ class Utilities:
     
 ################################################################################
     @staticmethod
-    async def get_channel(
+    async def select_channel(
         interaction: Interaction,
         guild: GuildData,
         channel_type: str,
         channel_prompt: Optional[Embed] = None
-    ) -> Optional[GuildChannel]:
+    ) -> Optional[Union[TextChannel, ForumChannel]]:
 
         options = [
             SelectOption(

--- a/Utilities/Utilities.py
+++ b/Utilities/Utilities.py
@@ -18,11 +18,13 @@ from discord import (
     ChannelType,
     User,
     Role,
-    Emoji
+    Emoji, SelectOption
 )
 from discord.abc import GuildChannel
 
 from Enums import Timezone
+from UI.Common import FroggeSelectView
+from UI.Common.FroggeMultiMenuSelect import FroggeMultiMenuSelect
 from .Colors import CustomColor
 from .ErrorMessage import ErrorMessage
 
@@ -581,6 +583,77 @@ class Utilities:
         
         return image_url
     
+################################################################################
+    @staticmethod
+    async def get_channel(
+        interaction: Interaction,
+        guild: GuildData,
+        channel_type: str,
+        channel_prompt: Optional[Embed] = None
+    ) -> Optional[GuildChannel]:
+
+        options = [
+            SelectOption(
+                label=channel.name,
+                value=str(channel.id),
+            )
+            for channel in guild.parent.channels
+            if channel.type == ChannelType.category
+        ]
+
+        prompt = Utilities.make_embed(
+            title="__Category Selection__",
+            description=(
+                "Please select the category of the channel you would like to use"
+                f"for the `{channel_type}`."
+            )
+        )
+        view = FroggeMultiMenuSelect(interaction.user, None, options)
+
+        await interaction.respond(embed=prompt, view=view)
+        await view.wait()
+
+        if not view.complete or view.value is False:
+            return
+
+        category_id = int(view.value)
+        category = await guild.get_or_fetch_channel(category_id)
+
+        if not category:
+            error = Utilities.make_embed(
+                title="__Invalid Category__",
+                description="The category you selected is somehow invalid. Please try again."
+            )
+            await interaction.respond(embed=error, ephemeral=True)
+            return
+
+        options = [
+            SelectOption(
+                label=channel.name,
+                value=str(channel.id),
+            )
+            for channel in category.channels  # type: ignore
+            if channel.type in (ChannelType.text, ChannelType.forum)
+        ]
+
+        prompt = channel_prompt or Utilities.make_embed(
+            title=f"__{channel_type.title()} Selection__",
+            description=(
+                f"Please select the specific channel you'd like to use for the "
+                f"`{channel_type.lower()}`."
+            )
+        )
+        view = FroggeMultiMenuSelect(interaction.user, None, options)
+
+        await interaction.respond(embed=prompt, view=view)
+        await view.wait()
+
+        if not view.complete or view.value is False:
+            return
+
+        channel_id = int(view.value)
+        return await guild.get_or_fetch_channel(channel_id)
+
 ################################################################################
     @staticmethod
     def string_clamp(text: str, length: int) -> str:


### PR DESCRIPTION
Created a new utility method that allows users to select a category, followed by a channel.

Also switched out all calls to the old `'listen_for` method (for channels)